### PR TITLE
Refactor: [PB-42] Update ref() blocks to always include package name to remove reference ambiguity 

### DIFF
--- a/models/netsuite/intermediate/int_netsuite__accountxperiod_exchange_rate_map.sql
+++ b/models/netsuite/intermediate/int_netsuite__accountxperiod_exchange_rate_map.sql
@@ -2,22 +2,22 @@
 
 with accounts as (
     select * 
-    from {{ ref('stg_netsuite__accounts') }}
+    from {{ ref('netsuite', 'stg_netsuite__accounts') }}
 ), 
 
 accounting_books as (
     select * 
-    from {{ ref('stg_netsuite__accounting_books') }}
+    from {{ ref('netsuite', 'stg_netsuite__accounting_books') }}
 ), 
 
 subsidiaries as (
     select * 
-    from {{ ref('stg_netsuite__subsidiaries') }}
+    from {{ ref('netsuite', 'stg_netsuite__subsidiaries') }}
 ),
 
 consolidated_exchange_rates as (
     select * 
-    from {{ ref('stg_netsuite__consolidated_exchange_rates') }}
+    from {{ ref('netsuite', 'stg_netsuite__consolidated_exchange_rates') }}
 ),
 
 period_exchange_rate_map as ( -- exchange rates used, by accounting period, to convert to parent subsidiary

--- a/models/netsuite/intermediate/int_netsuite__transaction_and_reporting_periods.sql
+++ b/models/netsuite/intermediate/int_netsuite__transaction_and_reporting_periods.sql
@@ -2,12 +2,12 @@
 
 with accounting_periods as (
     select * 
-    from {{ ref('stg_netsuite__accounting_periods') }}
+    from {{ ref('netsuite', 'stg_netsuite__accounting_periods') }}
 ),
 
 subsidiaries as (
     select * 
-    from {{ ref('stg_netsuite__subsidiaries') }}
+    from {{ ref('netsuite', 'stg_netsuite__subsidiaries') }}
 ),
 
 transaction_and_reporting_periods as ( 

--- a/models/netsuite/intermediate/int_netsuite__transaction_lines_w_accounting_period.sql
+++ b/models/netsuite/intermediate/int_netsuite__transaction_lines_w_accounting_period.sql
@@ -2,12 +2,12 @@
 
 with transactions as (
     select * 
-    from {{ ref('stg_netsuite__transactions') }}
+    from {{ ref('netsuite', 'stg_netsuite__transactions') }}
 ), 
 
 transaction_lines as (
     select * 
-    from {{ ref('stg_netsuite__transaction_lines') }}
+    from {{ ref('netsuite', 'stg_netsuite__transaction_lines') }}
 ),
 
 transaction_lines_w_accounting_period as ( -- transaction line totals, by accounts, accounting period and subsidiary

--- a/models/netsuite/intermediate/int_netsuite__transactions_with_converted_amounts.sql
+++ b/models/netsuite/intermediate/int_netsuite__transactions_with_converted_amounts.sql
@@ -2,22 +2,22 @@
 
 with transaction_lines_w_accounting_period as (
     select * 
-    from {{ ref('int_netsuite__transaction_lines_w_accounting_period') }}
+    from {{ ref('netsuite', 'int_netsuite__transaction_lines_w_accounting_period') }}
 ), 
 
 accountxperiod_exchange_rate_map as (
     select * 
-    from {{ ref('int_netsuite__accountxperiod_exchange_rate_map') }}
+    from {{ ref('netsuite', 'int_netsuite__accountxperiod_exchange_rate_map') }}
 ), 
 
 transaction_and_reporting_periods as (
     select * 
-    from {{ ref('int_netsuite__transaction_and_reporting_periods') }}
+    from {{ ref('netsuite', 'int_netsuite__transaction_and_reporting_periods') }}
 ), 
 
 accounts as (
     select * 
-    from {{ ref('stg_netsuite__accounts') }}
+    from {{ ref('netsuite', 'stg_netsuite__accounts') }}
 ),
 
 transactions_in_every_calculation_period_w_exchange_rates as (

--- a/models/netsuite/netsuite__balance_sheet.sql
+++ b/models/netsuite/netsuite__balance_sheet.sql
@@ -2,30 +2,30 @@
 
 with transactions_with_converted_amounts as (
     select * 
-    from {{ref('int_netsuite__transactions_with_converted_amounts')}}
+    from {{ ref('netsuite', 'int_netsuite__transactions_with_converted_amounts') }}
 ), 
 
 --Below is only used if balance sheet transaction detail columns are specified dbt_project.yml file.
 {% if var('balance_sheet_transaction_detail_columns') != []%}
 transaction_details as (
     select * 
-    from {{ ref('netsuite__transaction_details') }}
+    from {{ ref('netsuite', 'netsuite__transaction_details') }}
 ), 
 {% endif %}
 
 accounts as (
     select * 
-    from {{ ref('stg_netsuite__accounts') }}
+    from {{ ref('netsuite', 'stg_netsuite__accounts') }}
 ), 
 
 accounting_periods as (
     select * 
-    from {{ ref('stg_netsuite__accounting_periods') }}
+    from {{ ref('netsuite', 'stg_netsuite__accounting_periods') }}
 ), 
 
 subsidiaries as (
     select * 
-    from {{ ref('stg_netsuite__subsidiaries') }}
+    from {{ ref('netsuite', 'stg_netsuite__subsidiaries') }}
 ),
 
 balance_sheet as ( 

--- a/models/netsuite/netsuite__income_statement.sql
+++ b/models/netsuite/netsuite__income_statement.sql
@@ -2,50 +2,50 @@
 
 with transactions_with_converted_amounts as (
     select * 
-    from {{ ref('int_netsuite__transactions_with_converted_amounts') }}
+    from {{ ref('netsuite', 'int_netsuite__transactions_with_converted_amounts') }}
 ), 
 
 --Below is only used if income statement transaction detail columns are specified dbt_project.yml file.
 {% if var('income_statement_transaction_detail_columns') != []%}
 transaction_details as (
     select * 
-    from {{ ref('netsuite__transaction_details') }}
+    from {{ ref('netsuite', 'netsuite__transaction_details') }}
 ), 
 {% endif %}
 
 accounts as (
     select * 
-    from {{ ref('stg_netsuite__accounts') }}
+    from {{ ref('netsuite', 'stg_netsuite__accounts') }}
 ), 
 
 accounting_periods as (
     select * 
-    from {{ ref('stg_netsuite__accounting_periods') }}
+    from {{ ref('netsuite', 'stg_netsuite__accounting_periods') }}
 ),
 
 subsidiaries as (
     select * 
-    from {{ ref('stg_netsuite__subsidiaries') }}
+    from {{ ref('netsuite', 'stg_netsuite__subsidiaries') }}
 ),
 
 transaction_lines as (
     select * 
-    from {{ ref('stg_netsuite__transaction_lines') }}
+    from {{ ref('netsuite', 'stg_netsuite__transaction_lines') }}
 ),
 
 classes as (
     select * 
-    from {{ ref('stg_netsuite__classes') }}
+    from {{ ref('netsuite', 'stg_netsuite__classes') }}
 ),
 
 locations as (
     select * 
-    from {{ ref('stg_netsuite__locations') }}
+    from {{ ref('netsuite', 'stg_netsuite__locations') }}
 ),
 
 departments as (
     select * 
-    from {{ ref('stg_netsuite__departments') }}
+    from {{ ref('netsuite', 'stg_netsuite__departments') }}
 ),
 
 income_statement as (

--- a/models/netsuite/netsuite__transaction_details.sql
+++ b/models/netsuite/netsuite__transaction_details.sql
@@ -2,82 +2,82 @@
 
 with transactions_with_converted_amounts as (
     select * 
-    from {{ref('int_netsuite__transactions_with_converted_amounts')}}
+    from {{ ref('netsuite', 'int_netsuite__transactions_with_converted_amounts') }}
 ),
 
 accounts as (
     select * 
-    from {{ ref('stg_netsuite__accounts') }}
+    from {{ ref('netsuite', 'stg_netsuite__accounts') }}
 ),
 
 accounting_periods as (
     select * 
-    from {{ ref('stg_netsuite__accounting_periods') }}
+    from {{ ref('netsuite', 'stg_netsuite__accounting_periods') }}
 ),
 
 subsidiaries as (
     select * 
-    from {{ ref('stg_netsuite__subsidiaries') }}
+    from {{ ref('netsuite', 'stg_netsuite__subsidiaries') }}
 ),
 
 transaction_lines as (
     select * 
-    from {{ ref('stg_netsuite__transaction_lines') }}
+    from {{ ref('netsuite', 'stg_netsuite__transaction_lines') }}
 ),
 
 transactions as (
     select * 
-    from {{ ref('stg_netsuite__transactions') }}
+    from {{ ref('netsuite', 'stg_netsuite__transactions') }}
 ),
 
 income_accounts as (
     select * 
-    from {{ ref('stg_netsuite__income_accounts') }}
+    from {{ ref('netsuite', 'stg_netsuite__income_accounts') }}
 ),
 
 expense_accounts as (
     select * 
-    from {{ ref('stg_netsuite__expense_accounts') }}
+    from {{ ref('netsuite', 'stg_netsuite__expense_accounts') }}
 ),
 
 customers as (
     select * 
-    from {{ ref('stg_netsuite__customers') }}
+    from {{ ref('netsuite', 'stg_netsuite__customers') }}
 ),
 
 items as (
     select * 
-    from {{ ref('stg_netsuite__items') }}
+    from {{ ref('netsuite', 'stg_netsuite__items') }}
 ),
 
 locations as (
     select * 
-    from {{ ref('stg_netsuite__locations') }}
+    from {{ ref('netsuite', 'stg_netsuite__locations') }}
 ),
 
 vendors as (
     select * 
-    from {{ ref('stg_netsuite__vendors') }}
+    from {{ ref('netsuite', 'stg_netsuite__vendors') }}
 ),
 
 vendor_types as (
     select * 
-    from {{ ref('stg_netsuite__vendor_types') }}
+    from {{ ref('netsuite', 'stg_netsuite__vendor_types') }}
 ),
 
 departments as (
     select * 
-    from {{ ref('stg_netsuite__departments') }}
+    from {{ ref('netsuite', 'stg_netsuite__departments') }}
 ),
 
 currencies as (
     select * 
-    from {{ ref('stg_netsuite__currencies') }}
+    from {{ ref('netsuite', 'stg_netsuite__currencies') }}
 ),
 
 classes as (
     select *
-    from {{ ref('stg_netsuite__classes') }}
+    from {{ ref('netsuite', 'stg_netsuite__classes') }}
 ),
 
 transaction_details as (

--- a/models/netsuite/staging/stg_netsuite__accounting_books.sql
+++ b/models/netsuite/staging/stg_netsuite__accounting_books.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite__accounting_books_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite__accounting_books_tmp') }}
 
 ),
 

--- a/models/netsuite/staging/stg_netsuite__accounting_periods.sql
+++ b/models/netsuite/staging/stg_netsuite__accounting_periods.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite__accounting_periods_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite__accounting_periods_tmp') }}
 
 ),
 

--- a/models/netsuite/staging/stg_netsuite__accounts.sql
+++ b/models/netsuite/staging/stg_netsuite__accounts.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite__accounts_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite__accounts_tmp') }}
 
 ),
 

--- a/models/netsuite/staging/stg_netsuite__classes.sql
+++ b/models/netsuite/staging/stg_netsuite__classes.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite__classes_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite__classes_tmp') }}
 
 ),
 

--- a/models/netsuite/staging/stg_netsuite__consolidated_exchange_rates.sql
+++ b/models/netsuite/staging/stg_netsuite__consolidated_exchange_rates.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite__consolidated_exchange_rates_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite__consolidated_exchange_rates_tmp') }}
 
 ),
 

--- a/models/netsuite/staging/stg_netsuite__currencies.sql
+++ b/models/netsuite/staging/stg_netsuite__currencies.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite__currencies_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite__currencies_tmp') }}
 
 ),
 

--- a/models/netsuite/staging/stg_netsuite__customers.sql
+++ b/models/netsuite/staging/stg_netsuite__customers.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite__customers_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite__customers_tmp') }}
 
 ),
 

--- a/models/netsuite/staging/stg_netsuite__departments.sql
+++ b/models/netsuite/staging/stg_netsuite__departments.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite__departments_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite__departments_tmp') }}
 
 ),
 

--- a/models/netsuite/staging/stg_netsuite__expense_accounts.sql
+++ b/models/netsuite/staging/stg_netsuite__expense_accounts.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite__expense_accounts_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite__expense_accounts_tmp') }}
 
 ),
 

--- a/models/netsuite/staging/stg_netsuite__income_accounts.sql
+++ b/models/netsuite/staging/stg_netsuite__income_accounts.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite__income_accounts_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite__income_accounts_tmp') }}
 
 ),
 

--- a/models/netsuite/staging/stg_netsuite__items.sql
+++ b/models/netsuite/staging/stg_netsuite__items.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite__items_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite__items_tmp') }}
 
 ),
 

--- a/models/netsuite/staging/stg_netsuite__locations.sql
+++ b/models/netsuite/staging/stg_netsuite__locations.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite__locations_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite__locations_tmp') }}
 
 ),
 

--- a/models/netsuite/staging/stg_netsuite__subsidiaries.sql
+++ b/models/netsuite/staging/stg_netsuite__subsidiaries.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite__subsidiaries_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite__subsidiaries_tmp') }}
 
 ),
 

--- a/models/netsuite/staging/stg_netsuite__transaction_lines.sql
+++ b/models/netsuite/staging/stg_netsuite__transaction_lines.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite__transaction_lines_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite__transaction_lines_tmp') }}
 
 ),
 

--- a/models/netsuite/staging/stg_netsuite__transactions.sql
+++ b/models/netsuite/staging/stg_netsuite__transactions.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite__transactions_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite__transactions_tmp') }}
 
 ),
 

--- a/models/netsuite/staging/stg_netsuite__vendor_types.sql
+++ b/models/netsuite/staging/stg_netsuite__vendor_types.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite__vendor_types_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite__vendor_types_tmp') }}
 
 ),
 

--- a/models/netsuite/staging/stg_netsuite__vendors.sql
+++ b/models/netsuite/staging/stg_netsuite__vendors.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite__vendors_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite__vendors_tmp') }}
 
 ),
 

--- a/models/netsuite2/intermediate/base/int_netsuite2__accounting_periods.sql
+++ b/models/netsuite2/intermediate/base/int_netsuite2__accounting_periods.sql
@@ -2,18 +2,18 @@
 
 with accounting_periods as (
     select * 
-    from {{ ref('stg_netsuite2__accounting_periods') }}
+    from {{ ref('netsuite', 'stg_netsuite2__accounting_periods') }}
 ),
 
 accounting_period_fiscal_calendars as (
     select * 
-    from {{ ref('stg_netsuite2__accounting_period_fiscal_cal') }}
+    from {{ ref('netsuite', 'stg_netsuite2__accounting_period_fiscal_cal') }}
 ),
 
 {% if var('netsuite2__fiscal_calendar_enabled', false) %}
 fiscal_calendar as (
     select * 
-    from {{ ref('stg_netsuite2__fiscal_calendar') }}
+    from {{ ref('netsuite', 'stg_netsuite2__fiscal_calendar') }}
 ),
 
 joined as (

--- a/models/netsuite2/intermediate/base/int_netsuite2__accounts.sql
+++ b/models/netsuite2/intermediate/base/int_netsuite2__accounts.sql
@@ -3,13 +3,13 @@
 with accounts as (
 
     select *
-    from {{ ref('stg_netsuite2__accounts') }}
+    from {{ ref('netsuite', 'stg_netsuite2__accounts') }}
 ),
 
 account_types as (
 
     select *
-    from {{ ref('stg_netsuite2__account_types') }}
+    from {{ ref('netsuite', 'stg_netsuite2__account_types') }}
 ),
 
 joined as (

--- a/models/netsuite2/intermediate/base/int_netsuite2__customers.sql
+++ b/models/netsuite2/intermediate/base/int_netsuite2__customers.sql
@@ -3,13 +3,13 @@
 with customers as (
 
     select *
-    from {{ ref('stg_netsuite2__customers') }}
+    from {{ ref('netsuite', 'stg_netsuite2__customers') }}
 ),
 
 entity_address as (
 
     select *
-    from {{ ref('stg_netsuite2__entity_address') }}
+    from {{ ref('netsuite', 'stg_netsuite2__entity_address') }}
 ),
 
 joined as (

--- a/models/netsuite2/intermediate/base/int_netsuite2__locations.sql
+++ b/models/netsuite2/intermediate/base/int_netsuite2__locations.sql
@@ -3,13 +3,13 @@
 with locations as (
 
     select *
-    from {{ ref('stg_netsuite2__locations') }}
+    from {{ ref('netsuite', 'stg_netsuite2__locations') }}
 ),
 
 location_main_address as (
 
     select *
-    from {{ ref('stg_netsuite2__location_main_address') }}
+    from {{ ref('netsuite', 'stg_netsuite2__location_main_address') }}
 ),
 
 joined as (

--- a/models/netsuite2/intermediate/base/int_netsuite2__transaction_lines.sql
+++ b/models/netsuite2/intermediate/base/int_netsuite2__transaction_lines.sql
@@ -3,20 +3,20 @@
 with transaction_lines as (
 
     select *
-    from {{ ref('stg_netsuite2__transaction_lines') }}
+    from {{ ref('netsuite', 'stg_netsuite2__transaction_lines') }}
 ),
 
 transaction_accounting_lines as (
 
     select *
-    from {{ ref('stg_netsuite2__transaction_accounting_lines') }}
+    from {{ ref('netsuite', 'stg_netsuite2__transaction_accounting_lines') }}
 ),
 
 {% if var('netsuite2__multibook_accounting_enabled', false) %}
 accounting_books as (
 
     select *
-    from {{ ref('stg_netsuite2__accounting_books') }}
+    from {{ ref('netsuite', 'stg_netsuite2__accounting_books') }}
 ), 
 {% endif %}
 

--- a/models/netsuite2/intermediate/int_netsuite2__acctxperiod_exchange_rate_map.sql
+++ b/models/netsuite2/intermediate/int_netsuite2__acctxperiod_exchange_rate_map.sql
@@ -2,29 +2,29 @@
 
 with accounts as (
     select * 
-    from {{ ref('int_netsuite2__accounts') }}
+    from {{ ref('netsuite', 'int_netsuite2__accounts') }}
 ), 
 
 {% if var('netsuite2__multibook_accounting_enabled', false) %}
 accounting_books as (
     select * 
-    from {{ ref('stg_netsuite2__accounting_books') }}
+    from {{ ref('netsuite', 'stg_netsuite2__accounting_books') }}
 ),
 {% endif %}
 
 subsidiaries as (
     select * 
-    from {{ ref('stg_netsuite2__subsidiaries') }}
+    from {{ ref('netsuite', 'stg_netsuite2__subsidiaries') }}
 ),
 
 consolidated_exchange_rates as (
     select *
-    from {{ ref('stg_netsuite2__consolidated_exchange_rates') }}
+    from {{ ref('netsuite', 'stg_netsuite2__consolidated_exchange_rates') }}
 ),
 
 currencies as (
     select *
-    from {{ ref('stg_netsuite2__currencies') }}
+    from {{ ref('netsuite', 'stg_netsuite2__currencies') }}
 ),
 
 period_exchange_rate_map as ( -- exchange rates used, by accounting period, to convert to parent subsidiary

--- a/models/netsuite2/intermediate/int_netsuite2__tran_and_reporting_periods.sql
+++ b/models/netsuite2/intermediate/int_netsuite2__tran_and_reporting_periods.sql
@@ -2,12 +2,12 @@
 
 with accounting_periods as (
     select * 
-    from {{ ref('int_netsuite2__accounting_periods') }}
+    from {{ ref('netsuite', 'int_netsuite2__accounting_periods') }}
 ),
 
 subsidiaries as (
     select * 
-    from {{ ref('stg_netsuite2__subsidiaries') }}
+    from {{ ref('netsuite', 'stg_netsuite2__subsidiaries') }}
 ),
 
 transaction_and_reporting_periods as ( 

--- a/models/netsuite2/intermediate/int_netsuite2__tran_lines_w_accounting_period.sql
+++ b/models/netsuite2/intermediate/int_netsuite2__tran_lines_w_accounting_period.sql
@@ -2,12 +2,12 @@
 
 with transactions as (
     select * 
-    from {{ ref('stg_netsuite2__transactions') }}
+    from {{ ref('netsuite', 'stg_netsuite2__transactions') }}
 ), 
 
 transaction_lines as (
     select * 
-    from {{ ref('int_netsuite2__transaction_lines') }}
+    from {{ ref('netsuite', 'int_netsuite2__transaction_lines') }}
 ),
 
 transaction_lines_w_accounting_period as ( -- transaction line totals, by accounts, accounting period and subsidiary

--- a/models/netsuite2/intermediate/int_netsuite2__tran_with_converted_amounts.sql
+++ b/models/netsuite2/intermediate/int_netsuite2__tran_with_converted_amounts.sql
@@ -6,24 +6,24 @@
 
 with transaction_lines_w_accounting_period as (
   select * 
-  from {{ ref('int_netsuite2__tran_lines_w_accounting_period') }}
+  from {{ ref('netsuite', 'int_netsuite2__tran_lines_w_accounting_period') }}
 ), 
 
 {% if var('netsuite2__using_exchange_rate', true) %}
 accountxperiod_exchange_rate_map as (
   select * 
-  from {{ ref('int_netsuite2__acctxperiod_exchange_rate_map') }}
+  from {{ ref('netsuite', 'int_netsuite2__acctxperiod_exchange_rate_map') }}
 ), 
 {% endif %}
 
 transaction_and_reporting_periods as (
   select * 
-  from {{ ref('int_netsuite2__tran_and_reporting_periods') }}
+  from {{ ref('netsuite', 'int_netsuite2__tran_and_reporting_periods') }}
 ), 
 
 accounts as (
   select * 
-  from {{ ref('int_netsuite2__accounts') }}
+  from {{ ref('netsuite', 'int_netsuite2__accounts') }}
 ),
 
 transactions_in_every_calculation_period_w_exchange_rates as (

--- a/models/netsuite2/netsuite2__balance_sheet.sql
+++ b/models/netsuite2/netsuite2__balance_sheet.sql
@@ -13,7 +13,7 @@
 
 with transactions_with_converted_amounts as (
     select * 
-    from {{ref('int_netsuite2__tran_with_converted_amounts')}}
+    from {{ ref('netsuite', 'int_netsuite2__tran_with_converted_amounts') }}
 
     {% if is_incremental() %}
     where _fivetran_synced_date >= {{ netsuite.netsuite_lookback(from_date='max(_fivetran_synced_date)', datepart='day', interval=var('lookback_window', 3)) }}
@@ -24,28 +24,28 @@ with transactions_with_converted_amounts as (
 {% if var('balance_sheet_transaction_detail_columns') != []%}
 transaction_details as (
     select * 
-    from {{ ref('netsuite2__transaction_details') }}
+    from {{ ref('netsuite', 'netsuite2__transaction_details') }}
 ), 
 {% endif %}
 
 accounts as (
     select * 
-    from {{ ref('int_netsuite2__accounts') }}
+    from {{ ref('netsuite', 'int_netsuite2__accounts') }}
 ), 
 
 accounting_periods as (
     select * 
-    from {{ ref('int_netsuite2__accounting_periods') }}
+    from {{ ref('netsuite', 'int_netsuite2__accounting_periods') }}
 ), 
 
 subsidiaries as (
     select * 
-    from {{ ref('stg_netsuite2__subsidiaries') }}
+    from {{ ref('netsuite', 'stg_netsuite2__subsidiaries') }}
 ),
 
 currencies as (
     select *
-    from {{ ref('stg_netsuite2__currencies') }}
+    from {{ ref('netsuite', 'stg_netsuite2__currencies') }}
 ),
 
 balance_sheet as ( 

--- a/models/netsuite2/netsuite2__income_statement.sql
+++ b/models/netsuite2/netsuite2__income_statement.sql
@@ -13,7 +13,7 @@
 
 with transactions_with_converted_amounts as (
     select * 
-    from {{ ref('int_netsuite2__tran_with_converted_amounts') }}
+    from {{ ref('netsuite', 'int_netsuite2__tran_with_converted_amounts') }}
 
     {% if is_incremental() %}
     where _fivetran_synced_date >= {{ netsuite.netsuite_lookback(from_date='max(_fivetran_synced_date)', datepart='day', interval=var('lookback_window', 3))  }}
@@ -24,48 +24,48 @@ with transactions_with_converted_amounts as (
 {% if var('income_statement_transaction_detail_columns') != []%}
 transaction_details as (
     select * 
-    from {{ ref('netsuite2__transaction_details') }}
+    from {{ ref('netsuite', 'netsuite2__transaction_details') }}
 ), 
 {% endif %}
 
 accounts as (
     select * 
-    from {{ ref('int_netsuite2__accounts') }}
+    from {{ ref('netsuite', 'int_netsuite2__accounts') }}
 ), 
 
 accounting_periods as (
     select * 
-    from {{ ref('int_netsuite2__accounting_periods') }}
+    from {{ ref('netsuite', 'int_netsuite2__accounting_periods') }}
 ),
 
 subsidiaries as (
     select * 
-    from {{ ref('stg_netsuite2__subsidiaries') }}
+    from {{ ref('netsuite', 'stg_netsuite2__subsidiaries') }}
 ),
 
 currencies as (
     select *
-    from {{ ref('stg_netsuite2__currencies') }}
+    from {{ ref('netsuite', 'stg_netsuite2__currencies') }}
 ),
 
 transaction_lines as (
     select * 
-    from {{ ref('int_netsuite2__transaction_lines') }}
+    from {{ ref('netsuite', 'int_netsuite2__transaction_lines') }}
 ),
 
 classes as (
     select * 
-    from {{ ref('stg_netsuite2__classes') }}
+    from {{ ref('netsuite', 'stg_netsuite2__classes') }}
 ),
 
 locations as (
     select * 
-    from {{ ref('stg_netsuite2__locations') }}
+    from {{ ref('netsuite', 'stg_netsuite2__locations') }}
 ),
 
 departments as (
     select * 
-    from {{ ref('stg_netsuite2__departments') }}
+    from {{ ref('netsuite', 'stg_netsuite2__departments') }}
 ),
 
 income_statement as (

--- a/models/netsuite2/netsuite2__transaction_details.sql
+++ b/models/netsuite2/netsuite2__transaction_details.sql
@@ -16,7 +16,7 @@ with transaction_lines as (
       *,
       cast(_fivetran_synced as date) as transaction_line_fivetran_synced_date
 
-    from {{ ref('int_netsuite2__transaction_lines') }}
+    from {{ ref('netsuite', 'int_netsuite2__transaction_lines') }}
 
     {% if is_incremental() %}
     where cast(_fivetran_synced as date) >= {{ netsuite.netsuite_lookback(from_date='max(transaction_line_fivetran_synced_date)', datepart='day', interval=var('lookback_window', 3)) }}
@@ -25,69 +25,69 @@ with transaction_lines as (
 
 transactions_with_converted_amounts as (
     select * 
-    from {{ ref('int_netsuite2__tran_with_converted_amounts') }}
+    from {{ ref('netsuite', 'int_netsuite2__tran_with_converted_amounts') }}
 ),
 
 accounts as (
     select * 
-    from {{ ref('int_netsuite2__accounts') }}
+    from {{ ref('netsuite', 'int_netsuite2__accounts') }}
 ),
 
 accounting_periods as (
     select * 
-    from {{ ref('int_netsuite2__accounting_periods') }}
+    from {{ ref('netsuite', 'int_netsuite2__accounting_periods') }}
 ),
 
 subsidiaries as (
     select * 
-    from {{ ref('stg_netsuite2__subsidiaries') }}
+    from {{ ref('netsuite', 'stg_netsuite2__subsidiaries') }}
 ),
 
 transactions as (
     select * 
-    from {{ ref('stg_netsuite2__transactions') }}
+    from {{ ref('netsuite', 'stg_netsuite2__transactions') }}
 ),
 
 customers as (
     select * 
-    from {{ ref('int_netsuite2__customers') }}
+    from {{ ref('netsuite', 'int_netsuite2__customers') }}
 ),
 
 items as (
     select * 
-    from {{ ref('stg_netsuite2__items') }}
+    from {{ ref('netsuite', 'stg_netsuite2__items') }}
 ),
 
 locations as (
     select * 
-    from {{ ref('int_netsuite2__locations') }}
+    from {{ ref('netsuite', 'int_netsuite2__locations') }}
 ),
 
 vendors as (
     select * 
-    from {{ ref('stg_netsuite2__vendors') }}
+    from {{ ref('netsuite', 'stg_netsuite2__vendors') }}
 ),
 
 {% if var('netsuite2__using_vendor_categories', true) %}
 vendor_categories as (
     select * 
-    from {{ ref('stg_netsuite2__vendor_categories') }}
+    from {{ ref('netsuite', 'stg_netsuite2__vendor_categories') }}
 ),
 {% endif %}
 
 departments as (
     select * 
-    from {{ ref('stg_netsuite2__departments') }}
+    from {{ ref('netsuite', 'stg_netsuite2__departments') }}
 ),
 
 currencies as (
     select * 
-    from {{ ref('stg_netsuite2__currencies') }}
+    from {{ ref('netsuite', 'stg_netsuite2__currencies') }}
 ),
 
 classes as (
     select *
-    from {{ ref('stg_netsuite2__classes') }}
+    from {{ ref('netsuite', 'stg_netsuite2__classes') }}
 ),
 
 transaction_details as (

--- a/models/netsuite2/staging/stg_netsuite2__account_types.sql
+++ b/models/netsuite2/staging/stg_netsuite2__account_types.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__account_types_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__account_types_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__accounting_book_subsidiaries.sql
+++ b/models/netsuite2/staging/stg_netsuite2__accounting_book_subsidiaries.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__accounting_book_subsidiaries_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__accounting_book_subsidiaries_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__accounting_books.sql
+++ b/models/netsuite2/staging/stg_netsuite2__accounting_books.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__accounting_books_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__accounting_books_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__accounting_period_fiscal_cal.sql
+++ b/models/netsuite2/staging/stg_netsuite2__accounting_period_fiscal_cal.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__accounting_period_fiscal_cal_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__accounting_period_fiscal_cal_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__accounting_periods.sql
+++ b/models/netsuite2/staging/stg_netsuite2__accounting_periods.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__accounting_periods_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__accounting_periods_tmp') }}
 
 ),
 

--- a/models/netsuite2/staging/stg_netsuite2__accounts.sql
+++ b/models/netsuite2/staging/stg_netsuite2__accounts.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__accounts_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__accounts_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__classes.sql
+++ b/models/netsuite2/staging/stg_netsuite2__classes.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__classes_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__classes_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__consolidated_exchange_rates.sql
+++ b/models/netsuite2/staging/stg_netsuite2__consolidated_exchange_rates.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__consolidated_exchange_rates_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__consolidated_exchange_rates_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__currencies.sql
+++ b/models/netsuite2/staging/stg_netsuite2__currencies.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__currencies_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__currencies_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__customers.sql
+++ b/models/netsuite2/staging/stg_netsuite2__customers.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__customers_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__customers_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__departments.sql
+++ b/models/netsuite2/staging/stg_netsuite2__departments.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__departments_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__departments_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__employees.sql
+++ b/models/netsuite2/staging/stg_netsuite2__employees.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__employees_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__employees_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__entities.sql
+++ b/models/netsuite2/staging/stg_netsuite2__entities.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__entities_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__entities_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__entity_address.sql
+++ b/models/netsuite2/staging/stg_netsuite2__entity_address.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__entity_address_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__entity_address_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__fiscal_calendar.sql
+++ b/models/netsuite2/staging/stg_netsuite2__fiscal_calendar.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__fiscal_calendar_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__fiscal_calendar_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__items.sql
+++ b/models/netsuite2/staging/stg_netsuite2__items.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__items_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__items_tmp') }}
 
 ),
 

--- a/models/netsuite2/staging/stg_netsuite2__jobs.sql
+++ b/models/netsuite2/staging/stg_netsuite2__jobs.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__jobs_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__jobs_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__location_main_address.sql
+++ b/models/netsuite2/staging/stg_netsuite2__location_main_address.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__location_main_address_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__location_main_address_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__locations.sql
+++ b/models/netsuite2/staging/stg_netsuite2__locations.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__locations_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__locations_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__subsidiaries.sql
+++ b/models/netsuite2/staging/stg_netsuite2__subsidiaries.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__subsidiaries_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__subsidiaries_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__transaction_accounting_lines.sql
+++ b/models/netsuite2/staging/stg_netsuite2__transaction_accounting_lines.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__transaction_accounting_lines_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__transaction_accounting_lines_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__transaction_lines.sql
+++ b/models/netsuite2/staging/stg_netsuite2__transaction_lines.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__transaction_lines_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__transaction_lines_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__transactions.sql
+++ b/models/netsuite2/staging/stg_netsuite2__transactions.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__transactions_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__transactions_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__vendor_categories.sql
+++ b/models/netsuite2/staging/stg_netsuite2__vendor_categories.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__vendor_categories_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__vendor_categories_tmp') }}
 ),
 
 fields as (

--- a/models/netsuite2/staging/stg_netsuite2__vendors.sql
+++ b/models/netsuite2/staging/stg_netsuite2__vendors.sql
@@ -3,7 +3,7 @@
 with base as (
 
     select * 
-    from {{ ref('stg_netsuite2__vendors_tmp') }}
+    from {{ ref('netsuite', 'stg_netsuite2__vendors_tmp') }}
 
 ),
 


### PR DESCRIPTION


**Detail what changes this PR introduces**
- I am currently struggling to include the `netsuite` package as it has model names which clash with existing models in my main project.
  - Despite the dbt docs saying that `ref()` blocks should be able to handle for this, I am still encountering cases where references within the `netsuite` package are compiling to the incorrect model (i.e. the model in the main project rather than in the `netsuite` package itself).
  - This may be related to another GitHub issue currently open against dbt Core: 
    - https://github.com/dbt-labs/dbt-core/issues/11351
- This PR replaces all model `ref()` blocks to rather use the variant which takes the package name as an additional argument.
  - This makes the model references more robust when including this repo as a package.
